### PR TITLE
Use SSG for Join Page

### DIFF
--- a/client/components/join-page.jsx
+++ b/client/components/join-page.jsx
@@ -207,7 +207,7 @@ const JoinPage = ({
 
         const { valid: validCheckoutSession } = verifyCheckoutSessionResult.data;
 
-        if(validCheckoutSession && hasCookie('')) {
+        if(validCheckoutSession && hasCookie(COOKIE_NAMES.PENDING_MEMBER_EMAIL)) {
           deleteCookie(COOKIE_NAMES.PENDING_MEMBER_EMAIL);
           setShowSuccessState(true);
           return;

--- a/client/components/join-page.jsx
+++ b/client/components/join-page.jsx
@@ -11,7 +11,6 @@ import { getCookie, setCookie, deleteCookie, hasCookie } from 'cookies-next';
 import { useAuth } from '../lib/hooks/use-auth';
 import { TickIcon } from './svg-components';
 import Notice from './notice';
-// import { initStripe } from '../lib/stripe';
 import { useRouter } from 'next/router';
 import { COOKIE_NAMES } from '../lib/constants';
 
@@ -73,7 +72,6 @@ const JoinPage = ({
   declarationSectionDescription,
   termsAndConditionsPage,
   privacyPolicyPage,
-  error: stripeError,
   successMessage,
   specialisationOptions: specialisationOptionsString
 }) => {
@@ -237,8 +235,8 @@ const JoinPage = ({
   }, []);
 
   useEffect(() => {
-    if(processingError || stripeError) window.scrollTo(0, 0);
-  }, [processingError, stripeError]);
+    if(processingError) window.scrollTo(0, 0);
+  }, [processingError]);
 
   if (showSuccessState) {
     return <SuccessState message={successMessage} />;
@@ -248,7 +246,7 @@ const JoinPage = ({
     <Container className='prose my-10 md:my-20'>
       <h1>Join NZSE</h1>
       {
-        (processingError || stripeError) &&
+        (processingError) &&
         <Notice type='danger'>
           <span>
             An error occurred trying to process your request. Please try again later, or contact{' '}

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -8,3 +8,7 @@ export const PAGE_LINKS = {
 export const FIREBASE_ERROR_MESSAGE = {
   'auth/user-not-found': 'A user with that email address could not be found.'
 };
+
+export const COOKIE_NAMES = {
+  PENDING_MEMBER_EMAIL: '_nzse_pendingMemberEmail'
+};

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -2,3 +2,9 @@ export const PAGE_LINKS = {
   MEMBERSHIP_INFO: '/professionals/join-nzse',
   PASSWORD_RESET: '/password-reset'
 };
+
+// Maps an error code returned by firebase to prose
+// All error codes and what they mean: https://firebase.google.com/docs/auth/admin/errors
+export const FIREBASE_ERROR_MESSAGE = {
+  'auth/user-not-found': 'A user with that email address could not be found.'
+};

--- a/client/lib/hooks/use-auth.js
+++ b/client/lib/hooks/use-auth.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { signIn, signOut } from 'next-auth/react';
 import { sendPasswordResetEmail } from 'firebase/auth';
 import { firebaseAuth } from '../firebase';
+import { FIREBASE_ERROR_MESSAGE } from '../constants';
 
 /**
  * Fore more info on firebase authentication: https://firebase.google.com/docs/auth/web/start
@@ -20,12 +21,6 @@ const AuthContext = createContext({
   setAuthenticatedUser: null,
   resetUserPassword: null
 });
-
-// Maps an error code returned by firebase to prose
-// All error codes and what they mean: https://firebase.google.com/docs/auth/admin/errors
-const FIREBASE_ERROR_CODE_TO_MESSAGE_MAPPING = {
-  'auth/user-not-found': 'A user with that email address could not be found.'
-};
 
 export const AuthProvider = ({ children }) => {
   const [authLoading, setAuthLoading] = useState(null);
@@ -80,7 +75,7 @@ export const AuthProvider = ({ children }) => {
         setAuthError({
           status: 500,
           error,
-          message: FIREBASE_ERROR_CODE_TO_MESSAGE_MAPPING[error.code] || "Something went wrong. Please try again later."
+          message: FIREBASE_ERROR_MESSAGE[error.code] || "Something went wrong. Please try again later."
         });
         reject();
 

--- a/client/pages/api/stripe/verify-checkout-session.js
+++ b/client/pages/api/stripe/verify-checkout-session.js
@@ -1,0 +1,57 @@
+import { initStripe } from "../../../lib/stripe";
+
+const validRequestBody = (req) => {
+  if(!req.body) return false;
+  return Object.keys(req.body).every((key) => ['checkoutSessionId'].includes(key));
+};
+
+const findCheckoutSession = async (checkoutSessionId) => {
+  const stripe = await initStripe();
+  let successfulCheckoutSession = null;
+
+  const defaultError = {
+    status: 500,
+    message:
+      'Something went wrong. Please contact info@nzse.org.nz for more information about your request'
+  };
+
+  successfulCheckoutSession = await stripe.checkout.sessions.retrieve(checkoutSessionId);
+  if (!successfulCheckoutSession) throw new Error(defaultError.message);
+
+  return {
+    successfulCheckoutSession
+  };
+};
+
+export default async function handler(req, res) {
+  try {
+    if(!validRequestBody(req)) {
+      res.status(400).json({ message: "Expected a checkoutSessionId' field to be provided in the request body"});
+      return;
+    }
+
+    const { checkoutSessionId } = req.body;
+    const checkoutSession = await findCheckoutSession(checkoutSessionId);
+
+    // If a checkout session wasn't found, then the catch block will be executed. This is here as
+    // a secondary check to ensure that if stripe does not throw an error, but hasn't returned anything,
+    // then we consider it as an invalid checkout session
+    if(!checkoutSession) {
+      res.status(200).json({ valid: false });
+    }
+
+    res.status(200).json({ valid: true });
+
+  } catch(error) {
+    // If a checkout session was not found, stripe will throw an error. Return the result as a
+    // successful request, but the checkout session id supplied was not valid
+    if(error.statusCode === 404) {
+      res.status(200).json({ valid: false });
+      return;
+    }
+
+    res.status('500').json({
+      error: error.message
+    });
+  }
+}

--- a/client/pages/join.jsx
+++ b/client/pages/join.jsx
@@ -44,7 +44,6 @@ export const getStaticProps = async () => {
       memberships,
       joinPageProps: {
         ...joinPage,
-        error: null
       }
     }
   };

--- a/client/pages/join.jsx
+++ b/client/pages/join.jsx
@@ -4,13 +4,14 @@ import { graphqlClient } from '../lib/graphql-api';
 import { getJoinPage, getMemberships } from '../graphql/queries';
 import { initStripe } from '../lib/stripe';
 import { unwrapCollectionEntityResponse } from '../lib/utils';
-import { deleteCookie } from 'cookies-next';
 
 const attachPriceToMemberships = (membershipsCMS, stripePrices) => {
   return membershipsCMS.map((membershipCMS) => {
     const price = stripePrices.find(
       (membershipPrice) => membershipPrice.id === membershipCMS.stripePriceId
     );
+
+    if(!price) return null;
 
     const priceInCents = price.unit_amount_decimal || price.unit_amount;
     const priceInCentsNum = parseFloat(priceInCents);
@@ -21,28 +22,10 @@ const attachPriceToMemberships = (membershipsCMS, stripePrices) => {
       priceInCents,
       priceDollar
     };
-  });
+  }).filter((item) => !!item);
 };
 
-const findSuccessfulCheckoutSession = async (successfulSessionId, stripe) => {
-  let successfulCheckoutSession = null;
-
-  const defaultError = {
-    status: 500,
-    message:
-      'Something went wrong. Please contact info@nzse.org.nz for more information about your request'
-  };
-
-  successfulCheckoutSession = await stripe.checkout.sessions.retrieve(successfulSessionId);
-  if (!successfulCheckoutSession) throw new Error(defaultError.message);
-
-  return {
-    successfulCheckoutSession
-  };
-};
-
-export const getServerSideProps = async (context) => {
-  const { req, res, query } = context;
+export const getStaticProps = async () => {
 
   const [membershipsResponse, { data: joinPageData }] = await Promise.all([
     graphqlClient.query({ query: getMemberships }),
@@ -56,41 +39,12 @@ export const getServerSideProps = async (context) => {
 
   const joinPage = joinPageData?.joinPage?.data?.attributes;
 
-  // A 'successful_session_url' query  will exist if this page is redirected to by Stripe after a
-  // successful payment (see /api/stripe/checkout-session)
-  const { successful_session_id: successfulSessionId } = query || {};
-  let successfulCheckoutSession = null;
-  let exception = null;
-  if (successfulSessionId) {
-    try {
-      successfulCheckoutSession = await findSuccessfulCheckoutSession(successfulSessionId, stripe);
-
-      // If this cookie is not deleted, on render, client side code will run to delete the Firebase
-      // user whose email is the value of the cookie.
-      //
-      // This is because if this cookie exists AFTER the user is redirected from stripe checkout to
-      // the join page, the frontend assumes that the payment has failed or has been cancelled by the user,
-      // and therefore will issue an API call to remove pending member from Firebase users to make
-      // the email useable again for future attempts at member registration
-      deleteCookie('pendingMemberEmail', { req, res });
-    } catch (caughtException) {
-      exception = caughtException;
-    }
-  }
-
   return {
     props: {
       memberships,
       joinPageProps: {
         ...joinPage,
-        showPaymentSuccessState: !!successfulCheckoutSession,
-        error: exception
-          ? {
-              message:
-                'Something went wrong. Please contact info@nzse.org.nz for more information.',
-              status: 500
-            }
-          : null
+        error: null
       }
     }
   };


### PR DESCRIPTION
The join page loads too slowly because it was using SSR. To address this problem, the join page has been converted to use SSG.

- Transfer post-checkout session logic to client side - This logic happened serverside (during `getServerSideProps`) but is now happening client-side, with calls to a newly introduced api route (`/api/stripe/verify-checkout-session`) to help out.
- Use `getStaticProps` for Join page