### PR TITLE
On-demand Revalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ STRIPE_SECRET_KEY=
 # A json object containing Firebase auth credentials. Don't surround with quotation marks.
 FIREBASE_SERVICE_ACCOUNT_JSON=
 
+######################## Shared ########################
+REVALIDATE_TOKEN=
+
+
 ######################## Staging/Prod only ########################
 DATABASE_CA=
 # This should contain all the db details required to establish a connection with the db

--- a/.env.example
+++ b/.env.example
@@ -41,10 +41,8 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 # A json object containing Firebase auth credentials. Don't surround with quotation marks.
 FIREBASE_SERVICE_ACCOUNT_JSON=
-
-######################## Shared ########################
+# This should be set in the revalidate webhook Authorization header of the Strapi instance
 REVALIDATE_TOKEN=
-
 
 ######################## Staging/Prod only ########################
 DATABASE_CA=

--- a/client/pages/api/revalidate.js
+++ b/client/pages/api/revalidate.js
@@ -1,0 +1,24 @@
+export default async function handler(req, res) {
+  if(!req.headers.authorization) return res.status(400).json({ message: 'Expected a Authorization header with a revalidate token'});
+
+  const receivedToken = req.headers.authorization.replace('Basic ', '').trim();
+  if(receivedToken !== process.env.REVALIDATE_TOKEN) return res.status(401).json({ message: 'Invalid token '});
+
+  if(!req.body.entry) return res.status(400).json({ message: "Expected an 'entry' object in the request body"});
+
+  const updatedContent = req.body;
+
+  let slug = '/';
+  if(updatedContent.model === 'general-page') {
+    slug = updatedContent.entry.type.toLowerCase() === 'root' ? `/${updatedContent.entry.slug}` : `/${updatedContent.entry.type.toLowerCase()}/${updatedContent.entry.slug}`;
+  } else if (updatedContent.model === 'join-page' || updatedContent.model === 'membership') {
+    slug = '/join';
+  }
+
+  try {
+    await res.revalidate(slug);
+    return res.json({ revalidated: true });
+  } catch(error) {
+    return res.status(500).send('Error revalidating');
+  }
+}


### PR DESCRIPTION
This PR implements on-demand revalidation so that pages are revalidated when they are updated in the CMS.

- Add a webhook on Strapi that is triggerred when content is added or updated. The webhook issues a request to the api route `/api/revalidate`, which will manually revalidate the updated page